### PR TITLE
Re-add support for alternate crash upload providers 

### DIFF
--- a/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
+++ b/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
@@ -20,6 +20,7 @@ public class ModConfig {
     public CrashLogUploadType uploadCrashLogTo = CrashLogUploadType.GIST;
     public String uploadCustomUserAgent = null;
 
+    public boolean GISTUnlisted = false;
     public boolean disableReturnToMainMenu = false;
     public boolean deobfuscateStackTrace = true;
     public boolean debugModIdentification = false;

--- a/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
+++ b/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
@@ -18,6 +18,8 @@ public class ModConfig {
     private static ModConfig instance = null;
 
     public CrashLogUploadType uploadCrashLogTo = CrashLogUploadType.GIST;
+    public String uploadCustomUserAgent = null;
+
     public boolean disableReturnToMainMenu = false;
     public boolean deobfuscateStackTrace = true;
     public boolean debugModIdentification = false;

--- a/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
+++ b/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
@@ -3,7 +3,6 @@ package fudge.notenoughcrashes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import fudge.notenoughcrashes.platform.NecPlatform;
-import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.*;
 
@@ -12,12 +11,51 @@ public class ModConfig {
     public enum CrashLogUploadType {
         GIST,
         HASTE,
+        PASTEBIN,
         BYTEBIN
     }
 
+    public enum PastebinPrivacy {
+        PUBLIC("0"), //anyone can see it, appears in recently created
+        UNLISTED("1"); // only people with the link can see it
+//        PRIVATE(2) // only you can see it (doesn't make much sense). this doesn't allow for raw download, so disabling
+
+        private final String apiValue;
+
+        PastebinPrivacy(String apiValue) {
+            this.apiValue = apiValue;
+        }
+
+        public String getApiValue() {
+            return this.apiValue;
+        }
+    }
+
+    public enum PastebinExpiry {
+        NEVER("N"),
+        TENMIN("10M"),
+        ONEHOUR("1H"),
+        ONEDAY("1D"),
+        ONEWEEK("1W"),
+        TWOWEEK("2W"),
+        ONEMONTH("1M"),
+        SIXMONTH("6M"),
+        ONEYEAR("1Y");
+
+        private final String pastebinExpiryKey;
+        PastebinExpiry(String pastebinExpiry) {
+            this.pastebinExpiryKey = pastebinExpiry;
+        }
+
+        public String getPastebinExpiryKey() {
+            return pastebinExpiryKey;
+        }
+    }
     private static final File CONFIG_FILE = new File(NecPlatform.instance().getConfigDirectory().toFile(), NotEnoughCrashes.MOD_ID + ".json");
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static ModConfig instance = null;
+
+
 
     public CrashLogUploadType uploadCrashLogTo = CrashLogUploadType.GIST;
     public String uploadCustomUserAgent = null;
@@ -27,12 +65,17 @@ public class ModConfig {
 
     public String HASTEUrl = "https://hastebin.com/";
 
+    public String PASTEBINUploadKey = "";
+    public PastebinPrivacy PASTEBINPrivacy = PastebinPrivacy.PUBLIC;
+    public PastebinExpiry PASTEBINExpiry = PastebinExpiry.NEVER;
+
     public String BYTEBINUrl = "https://bytebin.lucko.me/";
 
     public boolean disableReturnToMainMenu = false;
     public boolean deobfuscateStackTrace = true;
     public boolean debugModIdentification = false;
     public boolean forceCrashScreen = false;
+
 
     public static ModConfig instance() {
         if (instance != null) {

--- a/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
+++ b/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
@@ -9,10 +9,16 @@ import java.io.*;
 public class ModConfig {
 
     public enum CrashLogUploadType {
-        GIST,
-        HASTE,
-        PASTEBIN,
-        BYTEBIN
+        GIST(5), // attempt last
+        HASTE(2),
+        PASTEBIN(), // requires configuration
+        BYTEBIN(1);
+
+        private final int defaultPriority;
+
+        CrashLogUploadType(int defaultPriority) { this.defaultPriority = defaultPriority; }
+        CrashLogUploadType() { this.defaultPriority = Integer.MIN_VALUE; }
+        public int getPriority() { return this.defaultPriority; }
     }
 
     public enum PastebinPrivacy {

--- a/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
+++ b/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
@@ -20,7 +20,9 @@ public class ModConfig {
     public CrashLogUploadType uploadCrashLogTo = CrashLogUploadType.GIST;
     public String uploadCustomUserAgent = null;
 
+    public String GISTUploadKey = "";
     public boolean GISTUnlisted = false;
+
     public boolean disableReturnToMainMenu = false;
     public boolean deobfuscateStackTrace = true;
     public boolean debugModIdentification = false;

--- a/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
+++ b/common/src/main/java/fudge/notenoughcrashes/ModConfig.java
@@ -10,7 +10,9 @@ import java.io.*;
 public class ModConfig {
 
     public enum CrashLogUploadType {
-        GIST
+        GIST,
+        HASTE,
+        BYTEBIN
     }
 
     private static final File CONFIG_FILE = new File(NecPlatform.instance().getConfigDirectory().toFile(), NotEnoughCrashes.MOD_ID + ".json");
@@ -22,6 +24,10 @@ public class ModConfig {
 
     public String GISTUploadKey = "";
     public boolean GISTUnlisted = false;
+
+    public String HASTEUrl = "https://hastebin.com/";
+
+    public String BYTEBINUrl = "https://bytebin.lucko.me/";
 
     public boolean disableReturnToMainMenu = false;
     public boolean deobfuscateStackTrace = true;

--- a/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
+++ b/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
@@ -59,7 +59,7 @@ public final class CrashLogUpload {
         Collections.addAll(fallBackTypes, ModConfig.CrashLogUploadType.values());
         fallBackTypes.sort(new CrashLogUploadTypeComparator());
         fallBackTypes.removeIf(fallbackType -> fallbackType.getPriority() < 0);
-        System.out.println(fallBackTypes);
+
         return  fallBackTypes;
     }
     private static ArrayList<ModConfig.CrashLogUploadType> getFallBackTypes() {
@@ -78,15 +78,12 @@ public final class CrashLogUpload {
     public static String upload(String text, Boolean fallBack) throws IOException {
         String URL = "";
         ModConfig.CrashLogUploadType uploadType;
-        System.out.println("starting upload");
         if (fallBack && getFallBackTypes().isEmpty()) {
-            System.out.println("fallback + empty");
             throw new IOException("no valid fallbacks");
         } else if (fallBack) {
-            System.out.println("fallback");
             uploadType = getFallBackTypes().remove(0);
         } else { uploadType = ModConfig.instance().uploadCrashLogTo; }
-        System.out.println("type:" + uploadType + uploadType.getPriority());
+
 
     try {
 
@@ -122,18 +119,14 @@ public final class CrashLogUpload {
     } catch (IOException exception) {
         URL = "";
         exception.printStackTrace();
-        System.out.println("caught exception");
     } finally {
         if (URL.equals("")) {
-            System.out.println("url is \"\"");
+
             URL = upload(text, true);
         } else {
-            System.out.println("1 "+URL);
-            System.out.println("rebuilding");
             getFallBackTypes(true); // rebuild
         }
     }
-        System.out.println(URL);
         return URL;
 
     }

--- a/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
+++ b/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
@@ -48,14 +48,17 @@ public final class CrashLogUpload {
     }
 
     public static String upload(String text) throws IOException {
-        // Don't give a fuck about your preferences
-        return uploadToGist(text);
-//        ModConfig.CrashLogUploadType type = ModConfig.instance().uploadCrashLogTo;
-//        if (type == ModConfig.CrashLogUploadType.GIST) {
-//            return uploadToGist(text);
-//        } else {
-//            return uploadToHaste(text);
-//        }
+        String URL;
+        ModConfig.CrashLogUploadType type = ModConfig.instance().uploadCrashLogTo;
+        switch (type) {
+            case GIST:
+                    URL = uploadToGist(text);
+                break;
+            default:
+                throw new IOException("fail, unknown provider");
+        }
+
+        return URL;
     }
 
     /**

--- a/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
+++ b/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
@@ -73,6 +73,11 @@ public final class CrashLogUpload {
                 }}
         );
         post.setEntity(new StringEntity(new Gson().toJson(body)));
+
+        if (ModConfig.instance().uploadCustomUserAgent != null) {
+            post.setHeader("User-Agent",ModConfig.instance().uploadCustomUserAgent);
+        }
+
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             CloseableHttpResponse response = httpClient.execute(post);
             String responseString = EntityUtils.toString(response.getEntity());

--- a/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
+++ b/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
@@ -3,6 +3,7 @@ package fudge.notenoughcrashes.utils;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
+import fudge.notenoughcrashes.ModConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -67,7 +68,7 @@ public final class CrashLogUpload {
 
         post.addHeader("Authorization", "token " + GIST_ACCESS_TOKEN);
 
-        GistPost body = new GistPost(true,
+        GistPost body = new GistPost(!ModConfig.instance().GISTUnlisted,
                 new HashMap<String, GistFile>() {{
                     put(fileName, new GistFile(text));
                 }}

--- a/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
+++ b/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
@@ -52,24 +52,35 @@ public final class CrashLogUpload {
         ModConfig.CrashLogUploadType type = ModConfig.instance().uploadCrashLogTo;
         switch (type) {
             case GIST:
+                String GISTuploadKey = ModConfig.instance().GISTUploadKey;
+                if (GISTuploadKey == "") {
                     URL = uploadToGist(text);
+                } else {
+                    URL = uploadToGist(text, GISTuploadKey);
+                }
                 break;
             default:
                 throw new IOException("fail, unknown provider");
         }
 
         return URL;
+
+    }
+
+    private static String uploadToGist(String text) throws IOException {
+        return uploadToGist(text, GIST_ACCESS_TOKEN);
     }
 
     /**
      * @return The link of the gist
      */
-    private static String uploadToGist(String text) throws IOException {
+    private static String uploadToGist(String text, String key) throws IOException {
         HttpPost post = new HttpPost("https://api.github.com/gists");
 
         String fileName = "crash.txt";
 
-        post.addHeader("Authorization", "token " + GIST_ACCESS_TOKEN);
+
+        post.addHeader("Authorization", "token " + key);
 
         GistPost body = new GistPost(!ModConfig.instance().GISTUnlisted,
                 new HashMap<String, GistFile>() {{

--- a/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
+++ b/common/src/main/java/fudge/notenoughcrashes/utils/CrashLogUpload.java
@@ -53,7 +53,7 @@ public final class CrashLogUpload {
     }
 
     public static String upload(String text) throws IOException {
-        String URL;
+        String URL = "";
         ModConfig.CrashLogUploadType type = ModConfig.instance().uploadCrashLogTo;
         switch (type) {
             case GIST:
@@ -74,9 +74,13 @@ public final class CrashLogUpload {
                 URL = uploadToByteBin(text);
                 break;
             default:
-                throw new IOException("fail, unknown provider");
+                // Unknown provider, defaulting to gist
+                URL = uploadToGist(text);
         }
-
+        if (URL == "") {
+            URL = uploadToGist(text); // if it can't upload here, it will error
+        }
+        //TODO: when im not on mobile, add catching of errors
         return URL;
 
     }


### PR DESCRIPTION
basically adds support for
https://gist.github.com
 -> requires personal access token, uses included one as default
 -> allows for private (link only) gists
https://github.com/lucko/bytebin
 -> custom server / backend support
https://github.com/seejohnrun/haste-server
 -> custom server / backend support
https://pastebin.com
 -> requires developer key, from a logged in account
 -> allows for custom expiry
 -> allows for public or unlisted
 
also allows for custom user agents, which is required for the public bytebin server, but allows for it to be overidden
since its a niche feature, its not generated by default