### PR TITLE
Fix stacktrace deobfuscator not being installed on dedicated servers

### DIFF
--- a/fabric/src/main/java/fudge/notenoughcrashes/mixins/MixinMain.java
+++ b/fabric/src/main/java/fudge/notenoughcrashes/mixins/MixinMain.java
@@ -1,5 +1,6 @@
 package fudge.notenoughcrashes.mixins;
 
+import fudge.notenoughcrashes.fabric.StacktraceDeobfuscator;
 import fudge.notenoughcrashes.platform.NecPlatformStorage;
 import fudge.notenoughcrashes.platform.fabric.FabricPlatform;
 import net.minecraft.server.Main;
@@ -13,5 +14,6 @@ public class MixinMain {
     @Inject(method = "main", at = @At("HEAD"))
     private static void createPlatformInstanceAsSoonAsPossibleOnClient(String[] args, CallbackInfo ci){
         NecPlatformStorage.INSTANCE_SET_ONLY_BY_SPECIFIC_PLATFORMS_VERY_EARLY = new FabricPlatform();
+        StacktraceDeobfuscator.init();
     }
 }


### PR DESCRIPTION
This broke in [3.3.1](https://github.com/natanfudge/Not-Enough-Crashes/commit/d2331c35103f7a3bc50f920e8ff2bad02351734a).
The [client-side mixin](https://github.com/natanfudge/Not-Enough-Crashes/blob/c1781a062323df1117541b8f2d86947680937c57/fabric/src/main/java/fudge/notenoughcrashes/mixins/client/MixinMain.java#L15-L18) had `StacktraceDeobfuscator.init();` while the server-side mixin did not.