### PR TITLE
Fix download-count icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Not Enough Crashes
 Discord:  [![Discord](https://img.shields.io/discord/219787567262859264.svg)](https://discord.gg/CFaCu97)  
-Fabric download:  [![CurseForge](https://cf.way2muchnoise.eu/not-enough-crashes.svg)](https://curseforge.com/minecraft/mc-mods/not-enough-crashes)
+Fabric download:  [![CurseForge](https://cf.way2muchnoise.eu/353890.svg)](https://curseforge.com/minecraft/mc-mods/not-enough-crashes)
 
-Forge download:  [![CurseForge](https://cf.way2muchnoise.eu/not-enough-crashes-forge.svg)](https://curseforge.com/minecraft/mc-mods/not-enough-crashes-forge)
+Forge download:  [![CurseForge](https://cf.way2muchnoise.eu/442354.svg)](https://curseforge.com/minecraft/mc-mods/not-enough-crashes-forge)
 
 Not Enough Crashes improves crashes in Minecraft significantly. For example, it returns the user to the title screen when crashing, instead of closing the game. 
 


### PR DESCRIPTION
There's currently an issue going on with [CurseForgeBadge](https://github.com/way2muchnoise/CurseForgeBadge-Unofficial) that causes certain mod names to not be found on their server ([see issue](https://github.com/way2muchnoise/CurseForgeBadge-Unofficial/issues/43)). I changed the README file to use their internal mod ids instead of their names for the time being. This should work as an immediate fix until CurseForgeBadge gets patched.